### PR TITLE
Grouping by 'job' in PCF Architecture Total CPU view

### DIFF
--- a/pcf/instances.json
+++ b/pcf/instances.json
@@ -81,7 +81,7 @@
       "job": {
         "resolution": 300000,
         "filters": [],
-        "template": "SYSTEM_CPU_LOAD_TOTAL = data(\"system.cpu.sys\", filter=filter(\"metric_source\", \"cloudfoundry\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])\nUSER_CPU_LOAD_TOTAL = data(\"system.cpu.user\", filter=filter(\"metric_source\", \"cloudfoundry\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])\nTOTAL_CPU_LOAD = SYSTEM_CPU_LOAD_TOTAL + USER_CPU_LOAD_TOTAL",
+        "template": "SYSTEM_CPU_LOAD_TOTAL = data(\"system.cpu.sys\", filter=filter(\"metric_source\", \"cloudfoundry\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\", \"job\"])\nUSER_CPU_LOAD_TOTAL = data(\"system.cpu.user\", filter=filter(\"metric_source\", \"cloudfoundry\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\", \"job\"])\nTOTAL_CPU_LOAD = SYSTEM_CPU_LOAD_TOTAL + USER_CPU_LOAD_TOTAL",
         "varName": "TOTAL_CPU_LOAD"
       },
       "coloring": {


### PR DESCRIPTION
So that that property gets returned by signalflow for the published time series