### PR TITLE
Remove some _missing_ filters from K8s pod nav view

### DIFF
--- a/kubernetes/pods.json
+++ b/kubernetes/pods.json
@@ -98,16 +98,6 @@
         "filters": [
           {
             "property": "_missing_",
-            "propertyValue": "name",
-            "type": "property"
-          },
-          {
-            "property": "_missing_",
-            "propertyValue": "image",
-            "type": "property"
-          },
-          {
-            "property": "_missing_",
             "propertyValue": "cluster",
             "type": "property"
           },
@@ -167,16 +157,6 @@
         "filters": [
           {
             "property": "_missing_",
-            "propertyValue": "name",
-            "type": "property"
-          },
-          {
-            "property": "_missing_",
-            "propertyValue": "image",
-            "type": "property"
-          },
-          {
-            "property": "_missing_",
             "propertyValue": "cluster",
             "type": "property"
           },
@@ -224,16 +204,6 @@
       "job": {
         "resolution": 60000,
         "filters": [
-          {
-            "property": "_missing_",
-            "propertyValue": "name",
-            "type": "property"
-          },
-          {
-            "property": "_missing_",
-            "propertyValue": "image",
-            "type": "property"
-          },
           {
             "property": "_missing_",
             "propertyValue": "cluster",
@@ -291,16 +261,6 @@
         "filters": [
           {
             "property": "_missing_",
-            "propertyValue": "name",
-            "type": "property"
-          },
-          {
-            "property": "_missing_",
-            "propertyValue": "image",
-            "type": "property"
-          },
-          {
-            "property": "_missing_",
             "propertyValue": "cluster",
             "type": "property"
           },
@@ -355,16 +315,6 @@
       "job": {
         "resolution": 60000,
         "filters": [
-          {
-            "property": "_missing_",
-            "propertyValue": "name",
-            "type": "property"
-          },
-          {
-            "property": "_missing_",
-            "propertyValue": "image",
-            "type": "property"
-          },
           {
             "property": "_missing_",
             "propertyValue": "cluster",
@@ -429,16 +379,6 @@
       "job": {
         "resolution": 60000,
         "filters": [
-          {
-            "property": "_missing_",
-            "propertyValue": "name",
-            "type": "property"
-          },
-          {
-            "property": "_missing_",
-            "propertyValue": "image",
-            "type": "property"
-          },
           {
             "property": "_missing_",
             "propertyValue": "cluster",


### PR DESCRIPTION
These are there to prevent old cAdvisor users from seeing the nav views, but they are conflicting with labels being propagated by neoagent and causing pods to not show