### PR TITLE
add uid to idTemplate to prevent pod name collision errors

### DIFF
--- a/kubernetes/architecture.json
+++ b/kubernetes/architecture.json
@@ -95,7 +95,7 @@
         "varName": "NODES",
         "valueLabel": "CPU Use",
         "valueFormat": "Percentage",
-        "idTemplate": "{{host}}",
+        "idTemplate": "{{host}} ({{kubernetes_cluster}})",
         "coloring": {
           "method": "quantile",
           "minValue": 0,
@@ -107,7 +107,7 @@
         "varName": "MASTERS",
         "valueLabel": "CPU Use",
         "valueFormat": "Percentage",
-        "idTemplate": "{{host}}",
+        "idTemplate": "{{host}} ({{kubernetes_cluster}})",
         "coloring": {
           "method": "quantile",
           "minValue": 0,

--- a/kubernetes/nodes.json
+++ b/kubernetes/nodes.json
@@ -9,7 +9,7 @@
   "requiredProperties": [
     "host"
   ],
-  "idTemplate": "{{host}}",
+  "idTemplate": "{{host}} ({{kubernetes_cluster}})",
   "idName": "Node",
   "mtsQuery": "_exists_:kubernetes_cluster",
   "singleHostSystemDashboardName": "K8s Node",

--- a/kubernetes/pods.json
+++ b/kubernetes/pods.json
@@ -12,7 +12,7 @@
   "filterProperties": [
     "host"
   ],
-  "idTemplate": "{{kubernetes_pod_name}}",
+  "idTemplate": "{{kubernetes_pod_name}} ({{kubernetes_pod_uid}})",
   "idName": "Pod",
   "mtsQuery": "_exists_:kubernetes_pod_name AND _exists_:kubernetes_cluster",
   "singleHostSystemDashboardName": "K8s Pod",


### PR DESCRIPTION
adds UUID as a parenthetical akin to docker container, this does not work with the v1 agent but does not really make the problem worse aside from a blank () appearing after the podname.  

this is being done to avoid collisions that a customer has been seeing when they are moving a pod from one cluster to another