### PR TITLE
Move Lambda job filters into the templates

### DIFF
--- a/aws/lambda.json
+++ b/aws/lambda.json
@@ -84,19 +84,8 @@
       "displayName": "Invocations",
       "job": {
         "resolution": 300000,
-        "filters": [
-          {
-            "property": "_exists_",
-            "propertyValue": "FunctionName",
-            "type": "property"
-          },
-          {
-            "property": "stat",
-            "propertyValue": "sum",
-            "type": "property"
-          }
-        ],
-        "template": "invocations_from_cw = data(\"Invocations\"{{#filter}}, filter={{{filter}}}{{/filter}}, rollup=\"sum\", extrapolation=\"null\", maxExtrapolations=-1).sum(by=[\"aws_function_name\", \"aws_function_version\", \"aws_region\", \"aws_account_id\"]).sum(over=\"{{{timeRange}}}\")\ninvocations_from_wrapper = data(\"function.invocations\", filter=filter(\"lambda_arn\", \"*\"){{#filter}} and {{{filter}}}{{/filter}}, rollup=\"sum\", extrapolation=\"null\", maxExtrapolations=-1).sum(by=[\"aws_function_name\", \"aws_function_version\", \"aws_region\", \"aws_account_id\"]).sum(over=\"{{{timeRange}}}\")\nINVOCATIONS = union(invocations_from_cw, invocations_from_wrapper)",
+        "filters": [],
+        "template": "invocations_from_cw = data(\"Invocations\", filter=filter(\"FunctionName\", \"*\") and filter(\"stat\", \"sum\"){{#filter}} and {{{filter}}}{{/filter}}, rollup=\"sum\", extrapolation=\"null\", maxExtrapolations=-1).sum(by=[\"aws_function_name\", \"aws_function_version\", \"aws_region\", \"aws_account_id\"]).sum(over=\"{{{timeRange}}}\")\ninvocations_from_wrapper = data(\"function.invocations\", filter=filter(\"lambda_arn\", \"*\"){{#filter}} and {{{filter}}}{{/filter}}, rollup=\"sum\", extrapolation=\"null\", maxExtrapolations=-1).sum(by=[\"aws_function_name\", \"aws_function_version\", \"aws_region\", \"aws_account_id\"]).sum(over=\"{{{timeRange}}}\")\nINVOCATIONS = union(invocations_from_cw, invocations_from_wrapper)",
         "varName": "INVOCATIONS"
       }
     },
@@ -106,19 +95,8 @@
       "displayName": "Throttles",
       "job": {
         "resolution": 300000,
-        "filters": [
-          {
-            "property": "_exists_",
-            "propertyValue": "FunctionName",
-            "type": "property"
-          },
-          {
-            "property": "stat",
-            "propertyValue": "sum",
-            "type": "property"
-          }
-        ],
-        "template": "THROTTLES = data(\"Throttles\"{{#filter}}, filter={{{filter}}}{{/filter}}, rollup=\"sum\", extrapolation=\"null\", maxExtrapolations=-1).sum(by=[\"aws_function_name\", \"aws_function_version\", \"aws_region\", \"aws_account_id\", \"aws_function_memory_size\", \"aws_function_runtime\", \"aws_function_timeout\", \"FunctionName\"]).sum(over=\"{{{timeRange}}}\")",
+        "filters": [],
+        "template": "THROTTLES = data(\"Throttles\", filter=filter(\"FunctionName\", \"*\") and filter(\"stat\", \"sum\"){{#filter}} and {{{filter}}}{{/filter}}, rollup=\"sum\", extrapolation=\"null\", maxExtrapolations=-1).sum(by=[\"aws_function_name\", \"aws_function_version\", \"aws_region\", \"aws_account_id\", \"aws_function_memory_size\", \"aws_function_runtime\", \"aws_function_timeout\", \"FunctionName\"]).sum(over=\"{{{timeRange}}}\")",
         "varName": "THROTTLES"
       }
     },
@@ -128,19 +106,8 @@
       "displayName": "Errors",
       "job": {
         "resolution": 300000,
-        "filters": [
-          {
-            "property": "_exists_",
-            "propertyValue": "FunctionName",
-            "type": "property"
-          },
-          {
-            "property": "stat",
-            "propertyValue": "sum",
-            "type": "property"
-          }
-        ],
-        "template": "errors_from_cw = data(\"Errors\"{{#filter}}, filter={{{filter}}}{{/filter}}, rollup=\"sum\", extrapolation=\"null\", maxExtrapolations=-1).sum(by=[\"aws_function_name\", \"aws_function_version\", \"aws_region\", \"aws_account_id\"]).sum(over=\"{{{timeRange}}}\")\nerrors_from_wrapper = data(\"function.errors\", filter=filter(\"lambda_arn\", \"*\"){{#filter}} and {{{filter}}}{{/filter}}, rollup=\"sum\", extrapolation=\"null\", maxExtrapolations=-1).sum(by=[\"aws_function_name\", \"aws_function_version\", \"aws_region\", \"aws_account_id\"]).sum(over=\"{{{timeRange}}}\")\nERRORS = union(errors_from_cw, errors_from_wrapper)",
+        "filters": [],
+        "template": "errors_from_cw = data(\"Errors\", filter=filter(\"FunctionName\", \"*\") and filter(\"stat\", \"sum\"){{#filter}} and {{{filter}}}{{/filter}}, rollup=\"sum\", extrapolation=\"null\", maxExtrapolations=-1).sum(by=[\"aws_function_name\", \"aws_function_version\", \"aws_region\", \"aws_account_id\"]).sum(over=\"{{{timeRange}}}\")\nerrors_from_wrapper = data(\"function.errors\", filter=filter(\"lambda_arn\", \"*\"){{#filter}} and {{{filter}}}{{/filter}}, rollup=\"sum\", extrapolation=\"null\", maxExtrapolations=-1).sum(by=[\"aws_function_name\", \"aws_function_version\", \"aws_region\", \"aws_account_id\"]).sum(over=\"{{{timeRange}}}\")\nERRORS = union(errors_from_cw, errors_from_wrapper)",
         "varName": "ERRORS"
       }
     },
@@ -150,14 +117,8 @@
       "displayName": "Duration",
       "job": {
         "resolution": 300000,
-        "filters": [
-          {
-            "property": "_exists_",
-            "propertyValue": "FunctionName",
-            "type": "property"
-          }
-        ],
-        "template": "cw_duration_sum = data(\"Duration\", filter=filter(\"stat\", \"sum\"){{#filter}} and {{{filter}}}{{/filter}}, rollup=\"sum\", extrapolation=\"null\", maxExtrapolations=-1).sum(by=[\"aws_function_name\", \"aws_function_version\", \"aws_region\", \"aws_account_id\"]).sum(over=\"{{{timeRange}}}\")\ncw_duration_count = data(\"Duration\", filter=filter(\"stat\", \"count\"){{#filter}} and {{{filter}}}{{/filter}}, rollup=\"sum\").sum(by=[\"aws_function_name\", \"aws_function_version\", \"aws_region\", \"aws_account_id\"]).sum(over=\"{{{timeRange}}}\")\nduration_from_cw = cw_duration_sum / cw_duration_count\nduration_from_wrapper = data(\"function.duration\", filter=filter(\"lambda_arn\", \"*\"){{#filter}} and {{{filter}}}{{/filter}}, rollup=\"average\", extrapolation=\"null\", maxExtrapolations=-1).sum(by=[\"aws_function_name\", \"aws_function_version\", \"aws_region\", \"aws_account_id\"]).sum(over=\"{{{timeRange}}}\")\nDURATION = union(duration_from_cw, duration_from_wrapper)",
+        "filters": [],
+        "template": "cw_duration_sum = data(\"Duration\", filter=filter(\"FunctionName\", \"*\") and filter(\"stat\", \"sum\"){{#filter}} and {{{filter}}}{{/filter}}, rollup=\"sum\", extrapolation=\"null\", maxExtrapolations=-1).sum(by=[\"aws_function_name\", \"aws_function_version\", \"aws_region\", \"aws_account_id\"]).sum(over=\"{{{timeRange}}}\")\ncw_duration_count = data(\"Duration\", filter=filter(\"FunctionName\", \"*\") and filter(\"stat\", \"count\"){{#filter}} and {{{filter}}}{{/filter}}, rollup=\"sum\").sum(by=[\"aws_function_name\", \"aws_function_version\", \"aws_region\", \"aws_account_id\"]).sum(over=\"{{{timeRange}}}\")\nduration_from_cw = cw_duration_sum / cw_duration_count\nduration_from_wrapper = data(\"function.duration\", filter=filter(\"lambda_arn\", \"*\"){{#filter}} and {{{filter}}}{{/filter}}, rollup=\"average\", extrapolation=\"null\", maxExtrapolations=-1).sum(by=[\"aws_function_name\", \"aws_function_version\", \"aws_region\", \"aws_account_id\"]).sum(over=\"{{{timeRange}}}\")\nDURATION = union(duration_from_cw, duration_from_wrapper)",
         "varName": "DURATION"
       }
     },
@@ -167,14 +128,8 @@
       "displayName": "Cold Starts",
       "job": {
         "resolution": 300000,
-        "filters": [
-          {
-            "property": "_exists_",
-            "propertyValue": "lambda_arn",
-            "type": "property"
-          }
-        ],
-        "template": "COLD_STARTS = data(\"function.cold_starts\"{{#filter}}, filter={{{filter}}}{{/filter}}, rollup=\"sum\", extrapolation=\"null\", maxExtrapolations=-1).sum(by=[\"aws_function_name\", \"aws_function_version\", \"aws_region\", \"aws_account_id\", \"lambda_arn\"]).sum(over=\"{{{timeRange}}}\")",
+        "filters": [],
+        "template": "COLD_STARTS = data(\"function.cold_starts\", filter=filter(\"lambda_arn\", \"*\"){{#filter}} and {{{filter}}}{{/filter}}, rollup=\"sum\", extrapolation=\"null\", maxExtrapolations=-1).sum(by=[\"aws_function_name\", \"aws_function_version\", \"aws_region\", \"aws_account_id\", \"lambda_arn\"]).sum(over=\"{{{timeRange}}}\")",
         "varName": "COLD_STARTS"
       }
     }


### PR DESCRIPTION
The CloudWatch-only filters should only be applied to the CloudWatch parts of
the SignalFlow. Fixes issue with data from Lambda wrappers not being returned
in orgs that do not sync CloudWatch metrics.