### PR TITLE
change quad backslashes to double backslashes for escaping

### DIFF
--- a/gcp/cloudfunctions.json
+++ b/gcp/cloudfunctions.json
@@ -8,7 +8,7 @@
   "idTemplate": "{{function_name}}",
   "alertQuery": "_exists_:function_name",
   "idName": "Function",
-  "mtsQuery": "(sf_metric:function/execution_count OR sf_metric:function/execution_times OR sf_metric:function/user_memory_bytes) AND _exists_:function_name",
+  "mtsQuery": "(sf_metric:function\\/execution_count OR sf_metric:function/execution_times OR sf_metric:function/user_memory_bytes) AND _exists_:function_name",
   "systemDashboardPrefix": "Cloud Functions Overview",
   "discoveryQuery": ["service:cloudfunctions"],
   "idProperties": [

--- a/gcp/cloudstorage.json
+++ b/gcp/cloudstorage.json
@@ -8,7 +8,7 @@
   "alertQuery": "_exists_:gcp_id",
   "idTemplate": "{{bucket_name}}",
   "idName": "Cloud Storage",
-  "mtsQuery": "sf_metric:network\\\\/received_bytes_count AND _exists_:gcp_id",
+  "mtsQuery": "sf_metric:network\\/received_bytes_count AND _exists_:gcp_id",
   "systemDashboardPrefix": "Cloud Storage Overview",
   "singleHostSystemDashboardName": "Cloud Storage Bucket",
   "discoveryQuery": ["service:storage"],


### PR DESCRIPTION
double backslashes for escaping mtsQuery forward slashes for gcp metrics 