### PR TITLE
release several aws dashboards

### DIFF
--- a/aws/cloudfront.json
+++ b/aws/cloudfront.json
@@ -1,6 +1,5 @@
 {
   "id": "cloudfront",
-  "unreleased": true,
   "displayName": "CloudFront Distributions",
   "category": "AWS",
   "categoryPriority": 100,

--- a/aws/dynamodb.json
+++ b/aws/dynamodb.json
@@ -1,6 +1,5 @@
 {
   "id": "awsdynamodb",
-  "unreleased": true,
   "displayName": "DynamoDB",
   "category": "AWS",
   "categoryPriority": 100,

--- a/aws/ebs_volumes.json
+++ b/aws/ebs_volumes.json
@@ -205,12 +205,12 @@
       "metricSelectors": [
         "VolumeTotalReadTime"
       ],
-      "description": "Total number of seconds spent by read operations that completed in a specified period of time",
-      "valueLabel": "Read Time (s)",
+      "description": "Total number of milliseconds spent by read operations that completed in a specified period of time",
+      "valueLabel": "Read Time (ms)",
       "job": {
         "resolution": 300000,
         "filters": [],
-        "template": "EBS_READTIME = data(\"VolumeTotalReadTime\", filter=filter(\"namespace\", \"AWS/EBS\") and filter(\"stat\", \"mean\") and filter(\"VolumeId\", \"*\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"VolumeId\"])",
+        "template": "EBS_READTIME = data(\"VolumeTotalReadTime\", filter=filter(\"namespace\", \"AWS/EBS\") and filter(\"stat\", \"mean\") and filter(\"VolumeId\", \"*\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"VolumeId\"]).scale(1000)",
         "varName": "EBS_READTIME"
       },
       "coloring": {
@@ -232,12 +232,12 @@
       "metricSelectors": [
         "VolumeTotalWriteTime"
       ],
-      "description": "Total number of seconds spent by write operations that completed in a specified period of time",
-      "valueLabel": "Write Time (s)",
+      "description": "Total number of milliseconds spent by write operations that completed in a specified period of time",
+      "valueLabel": "Write Time (ms)",
       "job": {
         "resolution": 300000,
         "filters": [],
-        "template": "EBS_WRITETIME = data(\"VolumeTotalWriteTime\", filter=filter(\"namespace\", \"AWS/EBS\") and filter(\"stat\", \"mean\") and filter(\"VolumeId\", \"*\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"VolumeId\"])",
+        "template": "EBS_WRITETIME = data(\"VolumeTotalWriteTime\", filter=filter(\"namespace\", \"AWS/EBS\") and filter(\"stat\", \"mean\") and filter(\"VolumeId\", \"*\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"VolumeId\"]).scale(1000)",
         "varName": "EBS_WRITETIME"
       },
       "coloring": {

--- a/aws/ebs_volumes.json
+++ b/aws/ebs_volumes.json
@@ -1,6 +1,5 @@
 {
   "id": "awsebs",
-  "unreleased": true,
   "displayName": "EBS Volumes",
   "category": "AWS",
   "categoryPriority": 100,

--- a/aws/ecs.json
+++ b/aws/ecs.json
@@ -1,6 +1,5 @@
 {
   "id": "awsecs",
-  "unreleased": true,
   "displayName": "Elastic Container Service",
   "category": "AWS",
   "categoryPriority": 100,
@@ -122,7 +121,7 @@
       },
       "coloring": {
         "method": "quantile",
-        "minValue": 0,
+        "minValue": 0
       }
     },
     {

--- a/aws/elasticache.json
+++ b/aws/elasticache.json
@@ -1,6 +1,5 @@
 {
   "id": "elasticache",
-  "unreleased": true,
   "displayName": "ElastiCache Clusters",
   "category": "AWS",
   "categoryPriority": 100,
@@ -61,6 +60,28 @@
   ],
   "metrics": [
     {
+      "id": "aws.elasticache.currconnections",
+      "type": "metric",
+      "displayName": "Current Connections",
+      "metricSelectors": [
+        "CurrConnections"
+      ],
+      "description": "Number of client connections (max: 65000)",
+      "valueLabel": "Connections",
+      "valueFormat": "Number",
+      "job": {
+        "resolution": 300000,
+        "filters": [],
+        "template": "CURRENT_CONNECTIONS = data(\"CurrConnections\", filter=filter(\"stat\", \"mean\") and filter(\"namespace\", \"AWS/ElastiCache\") and filter(\"CacheClusterId\", \"*\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"CacheClusterId\"])",
+        "varName": "CURRENT_CONNECTIONS"
+      },
+      "coloring": {
+        "method": "quantile",
+        "minValue": 0,
+        "maxValue": 65000
+      }
+    },
+    {
       "id": "aws.elasticache.hitrate",
       "type": "metric",
       "displayName": "Hit Ratio",
@@ -92,28 +113,6 @@
           "#e2ed6a",
           "#6bd37e"
         ]
-      }
-    },
-    {
-      "id": "aws.elasticache.currconnections",
-      "type": "metric",
-      "displayName": "Current Connections",
-      "metricSelectors": [
-        "CurrConnections"
-      ],
-      "description": "Number of client connections (max: 65000)",
-      "valueLabel": "Connections",
-      "valueFormat": "Number",
-      "job": {
-        "resolution": 300000,
-        "filters": [],
-        "template": "CURRENT_CONNECTIONS = data(\"CurrConnections\", filter=filter(\"stat\", \"mean\") and filter(\"namespace\", \"AWS/ElastiCache\") and filter(\"CacheClusterId\", \"*\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"CacheClusterId\"])",
-        "varName": "CURRENT_CONNECTIONS"
-      },
-      "coloring": {
-        "method": "quantile",
-        "minValue": 0,
-        "maxValue": 65000
       }
     },
     {

--- a/aws/elb.json
+++ b/aws/elb.json
@@ -1,6 +1,5 @@
 {
   "id": "elb",
-  "unreleased": true,
   "displayName": "ELB Load Balancers",
   "category": "AWS",
   "categoryPriority": 100,

--- a/aws/rds.json
+++ b/aws/rds.json
@@ -1,6 +1,5 @@
 {
   "id": "rds databases",
-  "unreleased": true,
   "displayName": "RDS Databases",
   "category": "AWS",
   "categoryPriority": 100,

--- a/aws/sns.json
+++ b/aws/sns.json
@@ -1,6 +1,5 @@
 {
   "id": "sns",
-  "unreleased": true,
   "displayName": "SNS Topics",
   "category": "AWS",
   "categoryPriority": 100,

--- a/aws/sqs.json
+++ b/aws/sqs.json
@@ -1,6 +1,5 @@
 {
   "id": "sqs queues",
-  "unreleased": true,
   "displayName": "SQS Queues",
   "category": "AWS",
   "categoryPriority": 100,

--- a/aws/sqs.json
+++ b/aws/sqs.json
@@ -42,8 +42,7 @@
     },
     {
       "property": "value",
-      "displayName": "Value",
-      "format": "Number"
+      "displayName": "Value"
     },
     {
       "property": "aws_engine",
@@ -81,6 +80,7 @@
       ],
       "description": "Number of in-flight, visible, delayed messages in queue",
       "valueLabel": "Queue Size",
+      "valueFormat": "Number",
       "job": {
         "resolution": 300000,
         "filters": [],
@@ -108,6 +108,7 @@
       ],
       "description": "Number of messages added to the queue per minute",
       "valueLabel": "Messages / min",
+      "valueFormat": "Number",
       "job": {
         "resolution": 300000,
         "filters": [],
@@ -130,6 +131,7 @@
       "id": "aws.sqs.msgrecv",
       "type": "metric",
       "displayName": "Received Messages",
+      "valueFormat": "Number",
       "metricSelectors": [
         "NumberOfMessagesReceived"
       ],
@@ -162,6 +164,7 @@
       ],
       "description": "Number of messages deleted from the queue",
       "valueLabel": "Deleted Messages / min",
+      "valueFormat": "Number",
       "job": {
         "resolution": 300000,
         "filters": [],
@@ -189,6 +192,7 @@
       ],
       "description": "Number of ReceiveMessage API calls that did not return a message per minute",
       "valueLabel": "Empty Messages / min",
+      "valueFormat": "Number",
       "job": {
         "resolution": 300000,
         "filters": [],
@@ -244,6 +248,7 @@
       ],
       "description": "Number of messages in the queue that are delayed and not available for reading immediately",
       "valueLabel": "Delayed Messages",
+      "valueFormat": "Number",
       "job": {
         "resolution": 300000,
         "filters": [],
@@ -271,6 +276,7 @@
       ],
       "description": "Number of messages sent to a client but have not yet been deleted or have not yet reached the end of their visibility window",
       "valueLabel": "In-Flight Messages",
+      "valueFormat": "Number",
       "job": {
         "resolution": 300000,
         "filters": [],
@@ -298,6 +304,7 @@
       ],
       "description": "Number of messages available for retrieval from the queue",
       "valueLabel": "Visible Messages",
+      "valueFormat": "Number",
       "job": {
         "resolution": 300000,
         "filters": [],


### PR DESCRIPTION
change column formatting on sqs, change seconds to milliseconds on read/write times on ebs,
flag as released: 
cloudfront, dynamodb, ebs volumes, ecs, elasticache, elb, rds, sns, and sqs.