### PR TITLE
Identifying K8s master nodes by tag

### DIFF
--- a/kubernetes/architecture.json
+++ b/kubernetes/architecture.json
@@ -68,7 +68,7 @@
     "job": {
       "resolution": 60000,
       "filters": [],
-      "template": "NODES = data(\"cpu.utilization\", filter=filter(\"kubernetes_cluster\", \"*\") and filter(\"kubernetes_role\", \"worker\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\", \"kubernetes_cluster\"])\nMASTERS = data(\"cpu.utilization\", filter=filter(\"kubernetes_cluster\", \"*\") and filter(\"kubernetes_role\", \"master\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\", \"kubernetes_cluster\"])"
+      "template": "NODES = data(\"cpu.utilization\", filter=filter(\"kubernetes_cluster\", \"*\") and (not filter(\"kubernetes_role\", \"master\") and not filter(\"sf_tags\", \"node-role_kubernetes_io_master\")){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\", \"kubernetes_cluster\"])\nMASTERS = data(\"cpu.utilization\", filter=filter(\"kubernetes_cluster\", \"*\") and (filter(\"kubernetes_role\", \"master\") or filter(\"sf_tags\", \"node-role_kubernetes_io_master\")){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\", \"kubernetes_cluster\"])"
     },
     "groupingStructure": {
       "key": "kubernetes_cluster",


### PR DESCRIPTION
They are still also identified by the original kubernetes_role=master dim

The new tag will be in use after the next agent release.  It will only
work with newer version of K8s that label nodes with their role using
the standard tag.