### PR TITLE
change extrapolation policies on several metrics and other minor changes

### DIFF
--- a/azure/app_service.json
+++ b/azure/app_service.json
@@ -26,7 +26,7 @@
   ],
   "listColumns": [
     {
-      "property": "azure_resource_name",
+      "property": "id",
       "displayName": "Resource Name"
     },
     {
@@ -66,7 +66,6 @@
       ],
       "description": "Color hosts by average response time (s)",
       "valueLabel": "Response Time (s)",
-      "valueFormat": "Number",
       "job": {
         "resolution": 60000,
         "filters": [
@@ -142,7 +141,6 @@
       ],
       "description": "Color hosts by amount of CPU in seconds consumed by th app",
       "valueLabel": "CPU Time (s)",
-      "valueFormat": "Number",
       "job": {
         "resolution": 60000,
         "filters": [

--- a/azure/batch.json
+++ b/azure/batch.json
@@ -1,7 +1,7 @@
 {
   "id": "azurebatch",
   "unreleased": true,
-  "displayName": "Batch",
+  "displayName": "Batch Accounts",
   "category": "Azure",
   "categoryPriority": 50,
   "type": "elemental",
@@ -26,7 +26,7 @@
   ],
   "listColumns": [
     {
-      "property": "azure_resource_name",
+      "property": "id",
       "displayName": "Resource Name"
     },
     {

--- a/azure/event_hubs.json
+++ b/azure/event_hubs.json
@@ -26,7 +26,7 @@
   ],
   "listColumns": [
     {
-      "property": "azure_resource_name",
+      "property": "id",
       "displayName": "Resource Name"
     },
     {

--- a/azure/logic_apps.json
+++ b/azure/logic_apps.json
@@ -26,7 +26,7 @@
   ],
   "listColumns": [
     {
-      "property": "azure_resource_name",
+      "property": "id",
       "displayName": "Resource Name"
     },
     {

--- a/azure/redis_cache.json
+++ b/azure/redis_cache.json
@@ -12,7 +12,7 @@
   "idTemplate": "{{azure_resource_name}}",
   "idName": "azure_redis",
   "mtsQuery": "resource_type:Microsoft.Cache\\/Redis",
-  "systemDashboardPrefix": "Azure Redis Cache Overview",
+  "systemDashboardPrefix": "Azure Redis Caches",
   "singleHostSystemDashboardName": "Azure Redis Cache",
   "discoveryQuery": [
     "resource_type:Microsoft.Cache/Redis"
@@ -27,7 +27,7 @@
   ],
   "listColumns": [
     {
-      "property": "azure_resource_name",
+      "property": "id",
       "displayName": "Resource Name"
     },
     {
@@ -111,7 +111,7 @@
         "usedmemory",
         "usedmemoryRss"
       ],
-      "description": "(usedmemoryRss / usedmemory) Color hosts by memory the OS has allocated vs memory allocated by Redis",
+      "description": "(usedmemoryRss / usedmemory) Color hosts by memory the OS has allocated vs memory allocated by Redis. A value of ~1 is ideal.",
       "valueLabel": "Ratio",
       "valueFormat": "Number",
       "job": {
@@ -133,12 +133,16 @@
       "coloring": {
         "method": "quantile",
         "minValue": 0,
+        "maxValue": 2,
         "range": [
-          "#bfd3e6",
-          "#9ebcda",
-          "#8c96c6",
-          "#8856a7",
-          "#810f7c"
+          "#ea1849",
+          "#ea1849",
+          "#e2ed6a",
+          "#6bd37e",
+          "#6bd37e",
+          "#e2ed6a",
+          "#ea1849",
+          "#ea1849"
         ]
       }
     },

--- a/azure/storage_accounts.json
+++ b/azure/storage_accounts.json
@@ -1,7 +1,7 @@
 {
   "id": "azurestorage",
   "unreleased": true,
-  "displayName": "Storage",
+  "displayName": "Storage Accounts",
   "category": "Azure",
   "categoryPriority": 30,
   "type": "elemental",
@@ -27,7 +27,7 @@
   ],
   "listColumns": [
     {
-      "property": "azure_resource_name",
+      "property": "id",
       "displayName": "Resource Name"
     },
     {
@@ -81,7 +81,7 @@
             "propertyValue": "true"
           }
         ],
-        "template": "INGRESS_TRAFFIC = data(\"Ingress\", filter={{#filter}}{{{filter}}}{{/filter}}, rollup=\"latest\", extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"azure_resource_name\", \"azure_resource_group_name\", \"azure_region\"])",
+        "template": "INGRESS_TRAFFIC = data(\"Ingress\", filter={{#filter}}{{{filter}}}{{/filter}}, rollup=\"average\", extrapolation=\"zero\", maxExtrapolations=-1).mean(by=[\"azure_resource_name\", \"azure_resource_group_name\", \"azure_region\"])",
         "varName": "INGRESS_TRAFFIC"
       },
       "coloring": {
@@ -119,8 +119,119 @@
             "propertyValue": "true"
           }
         ],
-        "template": "EGRESS_TRAFFIC = data(\"Egress\", filter={{#filter}}{{{filter}}}{{/filter}}, rollup=\"latest\", extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"azure_resource_name\", \"azure_resource_group_name\", \"azure_region\"])",
+        "template": "EGRESS_TRAFFIC = data(\"Egress\", filter={{#filter}}{{{filter}}}{{/filter}}, rollup=\"average\", extrapolation=\"zero\", maxExtrapolations=-1).mean(by=[\"azure_resource_name\", \"azure_resource_group_name\", \"azure_region\"])",
         "varName": "EGRESS_TRAFFIC"
+      },
+      "coloring": {
+        "method": "quantile",
+        "minValue": 0,
+        "range": [
+          "#bfd3e6",
+          "#9ebcda",
+          "#8c96c6",
+          "#8856a7",
+          "#810f7c"
+        ]
+      }
+    },
+    {
+      "id": "azure.storage.success_latency",
+      "type": "metric",
+      "displayName": "Sucecssful Latency(ms)",
+      "metricSelectors": [
+        "Egress"
+      ],
+      "description": "Color hosts by amount of average latency (ms) of successful requests. This does not include network latency.",
+      "valueLabel": "Latency (ms)",
+      "job": {
+        "resolution": 60000,
+        "filters": [
+          {
+            "property": "resource_type",
+            "propertyValue": "Microsoft.Storage/storageAccounts",
+            "type": "property"
+          },
+          {
+            "property": "primary_aggregation_type",
+            "propertyValue": "true"
+          }
+        ],
+        "template": "SUCCESS_LATENCY = data(\"SuccessServerLatency\", filter={{#filter}}{{{filter}}}{{/filter}}, rollup=\"average\", extrapolation=\"zero\", maxExtrapolations=-1).mean(by=[\"azure_resource_name\", \"azure_resource_group_name\", \"azure_region\"])",
+        "varName": "SUCCESS_LATENCY"
+      },
+      "coloring": {
+        "method": "quantile",
+        "minValue": 0,
+        "range": [
+          "#bfd3e6",
+          "#9ebcda",
+          "#8c96c6",
+          "#8856a7",
+          "#810f7c"
+        ]
+      }
+    },
+    {
+      "id": "azure.storage.e2elatency",
+      "type": "metric",
+      "displayName": "Sucecssful E2E Latency(ms)",
+      "metricSelectors": [
+        "Egress"
+      ],
+      "description": "Color hosts by amount of average end-to-end latency (ms) of successful requests",
+      "valueLabel": "Latency (ms)",
+      "job": {
+        "resolution": 60000,
+        "filters": [
+          {
+            "property": "resource_type",
+            "propertyValue": "Microsoft.Storage/storageAccounts",
+            "type": "property"
+          },
+          {
+            "property": "primary_aggregation_type",
+            "propertyValue": "true"
+          }
+        ],
+        "template": "SUCCESS_E2ELATENCY = data(\"SuccessE2ELatency\", filter={{#filter}}{{{filter}}}{{/filter}}, rollup=\"average\", extrapolation=\"zero\", maxExtrapolations=-1).mean(by=[\"azure_resource_name\", \"azure_resource_group_name\", \"azure_region\"])",
+        "varName": "SUCCESS_E2ELATENCY"
+      },
+      "coloring": {
+        "method": "quantile",
+        "minValue": 0,
+        "range": [
+          "#bfd3e6",
+          "#9ebcda",
+          "#8c96c6",
+          "#8856a7",
+          "#810f7c"
+        ]
+      }
+    },
+    {
+      "id": "azure.storage.transactions",
+      "type": "metric",
+      "displayName": "Transactions",
+      "metricSelectors": [
+        "Egress"
+      ],
+      "description": "Color hosts by total number of transactions in the past minute",
+      "valueLabel": "Transactions",
+      "job": {
+        "resolution": 60000,
+        "filters": [
+          {
+            "property": "resource_type",
+            "propertyValue": "Microsoft.Storage/storageAccounts",
+            "type": "property"
+          },
+          {
+            "property": "primary_aggregation_type",
+            "propertyValue": "true"
+          }
+        ],
+        "template": "TRANSACTIONS = data(\"Transactions\", filter={{#filter}}{{{filter}}}{{/filter}}, rollup=\"sum\", extrapolation=\"zero\", maxExtrapolations=-1).mean(by=[\"azure_resource_name\", \"azure_resource_group_name\", \"azure_region\"])",
+        "varName": "TRANSACTIONS"
       },
       "coloring": {
         "method": "quantile",

--- a/azure/virtual_machines.json
+++ b/azure/virtual_machines.json
@@ -27,7 +27,7 @@
   ],
   "listColumns": [
     {
-      "property": "azure_resource_name",
+      "property": "id",
       "displayName": "Instance Name"
     },
     {
@@ -159,7 +159,8 @@
       "type": "metric",
       "displayName": "Disk Write Bytes",
       "metricSelectors": [
-        "Disk Write Bytes"
+        "Disk Write Bytes",
+        "Disk Write Bytes/Sec"
       ],
       "description": "Color hosts based on bytes written to disk per second",
       "valueLabel": "Bytes Written",
@@ -168,17 +169,12 @@
         "resolution": 60000,
         "filters": [
           {
-            "property": "resource_type",
-            "propertyValue": "Microsoft.Compute/virtualMachines",
-            "type": "property"
-          },
-          {
-            "property": "aggregation_type",
-            "propertyValue": "total",
+            "property": "primary_aggregation_type",
+            "propertyValue": "true",
             "type": "property"
           }
         ],
-        "template": "DISK_WRITE_BYTES = data(\"Disk Write Bytes\", filter={{#filter}}{{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"azure_resource_name\", \"azure_resource_group_name\", \"azure_region\"])",
+        "template": "DISK_WRITE_BYTES = data(\"Disk Write Bytes*\", filter=filter(\"resource_type\", \"Microsoft.Compute/virtualMachines\") or filter(\"resource_type\", \"Microsoft.ClassicCompute/virtualMachines\") and {{#filter}}{{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"azure_resource_name\", \"azure_resource_group_name\", \"azure_region\"])",
         "varName": "DISK_WRITE_BYTES"
       },
       "coloring": {
@@ -198,7 +194,8 @@
       "type": "metric",
       "displayName": "Disk Read Bytes",
       "metricSelectors": [
-        "Disk Read Bytes"
+        "Disk Read Bytes",
+        "Disk Read Bytes/Sec"
       ],
       "description": "Color hosts based on bytes read from disk per second",
       "valueLabel": "Bytes Read",
@@ -207,17 +204,12 @@
         "resolution": 60000,
         "filters": [
           {
-            "property": "resource_type",
-            "propertyValue": "Microsoft.Compute/virtualMachines",
-            "type": "property"
-          },
-          {
-            "property": "aggregation_type",
-            "propertyValue": "total",
+            "property": "primary_aggregation_type",
+            "propertyValue": "true",
             "type": "property"
           }
         ],
-        "template": "DISK_READ_BYTES = data(\"Disk Read Bytes\", filter={{#filter}}{{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"azure_resource_name\", \"azure_resource_group_name\", \"azure_region\"])",
+        "template": "DISK_READ_BYTES = data(\"Disk Read Bytes*\", filter=filter(\"resource_type\", \"Microsoft.Compute/virtualMachines\") or filter(\"resource_type\", \"Microsoft.ClassicCompute/virtualMachines\") and {{#filter}}{{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"azure_resource_name\", \"azure_resource_group_name\", \"azure_region\"])",
         "varName": "DISK_READ_BYTES"
       },
       "coloring": {
@@ -241,7 +233,6 @@
       ],
       "description": "Color hosts based on disk write operations per second",
       "valueLabel": "Write Ops",
-      "valueFormat": "Number",
       "job": {
         "resolution": 60000,
         "filters": [
@@ -275,7 +266,6 @@
       ],
       "description": "Color hosts based on disk read operations per second",
       "valueLabel": "Read Ops",
-      "valueFormat": "Number",
       "job": {
         "resolution": 60000,
         "filters": [


### PR DESCRIPTION
change list columns to use "id" instead of "azure_resource_name" so names are clickable links
fix value formats for several metrics to not use scientific notation
rename Batch to Batch Accounts

rename Storage to Storage Accounts
add latency and transaction count metrics to storage

fix redis cache overview not showing up
recoloring on Redis Cache memory fragmentation ratio now red to green

add classic compute metrics for Disk Read/Write Bytes in virtual machines
